### PR TITLE
Load collections of different resources on change

### DIFF
--- a/src/components/CollectionList.vue
+++ b/src/components/CollectionList.vue
@@ -168,13 +168,6 @@ export default {
 		}
 	},
 
-	mounted() {
-		actions.fetchCollectionsByResource({
-			resourceType: this.type,
-			resourceId: this.id
-		})
-	},
-
 	watch: {
 		type() {
 			if (this.isActive) {
@@ -200,6 +193,13 @@ export default {
 				})
 			}
 		}
+	},
+
+	mounted() {
+		actions.fetchCollectionsByResource({
+			resourceType: this.type,
+			resourceId: this.id
+		})
 	},
 
 	methods: {

--- a/src/components/CollectionList.vue
+++ b/src/components/CollectionList.vue
@@ -163,12 +163,29 @@ export default {
 			return options
 		}
 	},
+
 	mounted() {
 		actions.fetchCollectionsByResource({
 			resourceType: this.type,
 			resourceId: this.id
 		})
 	},
+
+	watch: {
+		type() {
+			actions.fetchCollectionsByResource({
+				resourceType: this.type,
+				resourceId: this.id
+			})
+		},
+		id() {
+			actions.fetchCollectionsByResource({
+				resourceType: this.type,
+				resourceId: this.id
+			})
+		}
+	},
+
 	methods: {
 		select(selectedOption, id) {
 			if (selectedOption.method === METHOD_CREATE_COLLECTION) {

--- a/src/components/CollectionList.vue
+++ b/src/components/CollectionList.vue
@@ -111,6 +111,10 @@ export default {
 		name: {
 			type: String,
 			default: ''
+		},
+		isActive: {
+			type: Boolean,
+			default: true
 		}
 	},
 	data() {
@@ -173,16 +177,28 @@ export default {
 
 	watch: {
 		type() {
-			actions.fetchCollectionsByResource({
-				resourceType: this.type,
-				resourceId: this.id
-			})
+			if (this.isActive) {
+				actions.fetchCollectionsByResource({
+					resourceType: this.type,
+					resourceId: this.id
+				})
+			}
 		},
 		id() {
-			actions.fetchCollectionsByResource({
-				resourceType: this.type,
-				resourceId: this.id
-			})
+			if (this.isActive) {
+				actions.fetchCollectionsByResource({
+					resourceType: this.type,
+					resourceId: this.id
+				})
+			}
+		},
+		isActive(isActive) {
+			if (isActive) {
+				actions.fetchCollectionsByResource({
+					resourceType: this.type,
+					resourceId: this.id
+				})
+			}
 		}
 	},
 


### PR DESCRIPTION
Fix #814 

While this works, it now immediately causes a request when changing a Talk room, even if the sidebar tab is not the shown one.
Anyone has an idea? @marcoambrosini @juliushaertl 